### PR TITLE
Don't force ASCII, fix "wide character in print"

### DIFF
--- a/gosf2github.pl
+++ b/gosf2github.pl
@@ -86,7 +86,6 @@ foreach my $ticket (@tickets) {
     }
 
     my $body = $ticket->{description};
-    $body = make_ascii($body);
 
     # fix SF-specific markdown
     $body =~ s/\~\~\~\~/```/g;
@@ -135,7 +134,7 @@ foreach my $ticket (@tickets) {
 
     my $issue =
     {
-        "title" => make_ascii($ticket->{summary}),
+        "title" => $ticket->{summary},
         "body" => $body,
         "created_at" => cvt_time($ticket->{created_date}),    ## check
         "assignee" => $assignee,
@@ -157,7 +156,7 @@ foreach my $ticket (@tickets) {
         issue => $issue,
         comments => \@comments
     };
-    my $str = $json->encode( $req );
+    my $str = $json->utf8->encode( $req );
     #print $str,"\n";
     my $jsfile = 'foo.json';
     open(F,">$jsfile") || die $jsfile;
@@ -216,23 +215,6 @@ sub map_priority {
     if ($pr > 5) {
         return ("high priority");
     }
-}
-
-sub make_ascii {
-    my $s = shift;
-    $_ = $s;
-
-    tr [\200-\377]
-        [\000-\177];   # see 'man perlop', section on tr/
-    # weird ascii characters should be excluded
-    tr/\0-\10//d;   # remove weird characters; ascii 0-8
-    # preserve \11 (9 - tab) and \12 (10-linefeed)
-    tr/\13\14//d;   # remove weird characters; 11,12
-    # preserve \15 (13 - carriage return)
-    tr/\16-\37//d;  # remove 14-31 (all rest before space)
-    tr/\177//d;     # remove DEL character
-
-    return $_;
 }
 
 sub scriptname {


### PR DESCRIPTION
Not sure why make_ascii was introduced, it does not seem to be needed per tests I just made and it does "break" non-ASCII. And I suppose it lets some unicode chars through still because I see "wide character warnings" even with stuff passed through it (for example for \u2026).

Removing it and encoding JSON to UTF-8 results in good unicode imports without warnings for the data I tested with.
